### PR TITLE
Fix building (error: invalid conversion from ‘const char*’ to ‘char*’…

### DIFF
--- a/dlls/aghl/agclient.cpp
+++ b/dlls/aghl/agclient.cpp
@@ -516,7 +516,7 @@ void AgClient::Say(CBasePlayer* pPlayer, say_type Type )
         //Weapon
         if (pPlayer && pPlayer->IsAlive() && !pPlayer->IsSpectator() && pPlayer->m_pActiveItem && pPlayer->m_pActiveItem->m_iId < MAX_WEAPONS)
         {
-          char* pWeapon = strstr(pPlayer->m_pActiveItem->pszName(),"weapon_");
+          char* pWeapon = (char*)strstr(pPlayer->m_pActiveItem->pszName(),"weapon_");
           if (pWeapon)
           {
             pText = pText + sprintf(pText,"%s",&pWeapon[7]);


### PR DESCRIPTION
Could not build on Linux
```
/home/freeslave/git_projects/hlsdk-xash3d/dlls/aghl/agclient.cpp: In member function ‘void AgClient::Say(CBasePlayer*, AgClient::say_type)’:
/home/freeslave/git_projects/hlsdk-xash3d/dlls/aghl/agclient.cpp:519:77: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
           char* pWeapon = strstr(pPlayer->m_pActiveItem->pszName(),"weapon_");
                                                                             ^
dlls/CMakeFiles/server.dir/build.make:2354: recipe for target 'dlls/CMakeFiles/server.dir/aghl/agclient.cpp.o' failed
make[2]: *** [dlls/CMakeFiles/server.dir/aghl/agclient.cpp.o] Error 1
CMakeFiles/Makefile2:125: recipe for target 'dlls/CMakeFiles/server.dir/all' failed
make[1]: *** [dlls/CMakeFiles/server.dir/all] Error 2
Makefile:76: recipe for target 'all' failed
make: *** [all] Error 2
```